### PR TITLE
Fix Link for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div>
             <ul>
                 <li>
-                    <a href="#search-engine-optimization">Search Engine Optimization</a>
+                    <a href="#content">Search Engine Optimization</a>
                 </li>
                 <li>
                     <a href="#online-reputation-management">Online Reputation Management</a>


### PR DESCRIPTION
The link at the top of the page did not take the user to the SEO paragraph below the background image.