### PR TITLE
Add text-align to p tag in CSS file

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -48,6 +48,7 @@ a {
 
 p {
     font-size: 16px;
+    text-align: justify;
 }
 
 .hero {


### PR DESCRIPTION
I added text-align: justify to the p element in the CSS file to get all the lines to align evenly on the sides of each paragraph.